### PR TITLE
Fix compilation with g++ 6.3.1

### DIFF
--- a/TrueTypeViewer/Makefile
+++ b/TrueTypeViewer/Makefile
@@ -6,8 +6,9 @@
 
 # Make the compiler use QT
 #QTDIR=/usr/share/qt3
+QT_LIBRARY=qt
 CPPFLAGS=-I${QTDIR}/include -D_STANDALONE_
-LDFLAGS=-L$(QTDIR)/lib -lqt
+LDFLAGS=-L$(QTDIR)/lib -l${QT_LIBRARY}
 
 truetypeviewerobjects = cvtviewerdialog.o moc_glyphviewerdialog.o \
 		cvtviewerdialogbase.o moc_glyphviewerdialogbase.o \

--- a/TrueTypeViewer/fontcache.cpp
+++ b/TrueTypeViewer/fontcache.cpp
@@ -35,6 +35,7 @@
 */
 
 #include <cassert>
+#include <cstdlib>
 #include <qglobal.h>
 #include <qimage.h>
 #include "fontcache.h"

--- a/TrueTypeViewer/fontcache.cpp
+++ b/TrueTypeViewer/fontcache.cpp
@@ -50,6 +50,8 @@ void MessageInstructionProcessor::addWarning (InstructionExceptionPtr newWarning
 
 /*** RasterCache ***/
 
+void rasterCallback(int y, int count, FT_Span*  spans, void* user);
+
 RasterCache::RasterCache (const InstructionProcessor::Points &points)
 {
 	FT_Raster raster;


### PR DESCRIPTION
A missing #include and function declaration currently do not allow the TrueTypeViewer to be built.